### PR TITLE
VSP-22558: Encrypt vault volumes & use launch templates

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -117,10 +117,6 @@ resource "aws_launch_template" "launch_template" {
   instance_type = var.instance_type
   user_data     = var.user_data
   key_name      = var.ssh_key_name
-  vpc_security_group_ids = concat(
-    [aws_security_group.lc_security_group.id],
-    var.additional_security_group_ids,
-  )
   ebs_optimized = var.root_volume_ebs_optimized
 
   iam_instance_profile {
@@ -133,6 +129,10 @@ resource "aws_launch_template" "launch_template" {
 
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
+    security_groups = concat(
+      [aws_security_group.lc_security_group.id],
+      var.additional_security_group_ids,
+    )
   }
 
   block_device_mappings {

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -116,13 +116,16 @@ resource "aws_launch_template" "launch_template" {
   image_id      = var.ami_id
   instance_type = var.instance_type
   user_data     = var.user_data
-
-  iam_instance_profile = aws_iam_instance_profile.instance_profile.name
   key_name             = var.ssh_key_name
-  security_groups = concat(
+  vpc_security_group_ids = concat(
     [aws_security_group.lc_security_group.id],
     var.additional_security_group_ids,
   )
+  ebs_optimized = var.root_volume_ebs_optimized
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.instance_profile.name
+  }
 
   placement {
     tenancy = var.tenancy
@@ -131,8 +134,6 @@ resource "aws_launch_template" "launch_template" {
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
   }
-
-  ebs_optimized = var.root_volume_ebs_optimized
 
   block_device_mappings {
     device_name = "/dev/xvda"

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -116,7 +116,7 @@ resource "aws_launch_template" "launch_template" {
   image_id      = var.ami_id
   instance_type = var.instance_type
   user_data     = var.user_data
-  key_name             = var.ssh_key_name
+  key_name      = var.ssh_key_name
   vpc_security_group_ids = concat(
     [aws_security_group.lc_security_group.id],
     var.additional_security_group_ids,

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -120,6 +120,10 @@ resource "aws_launch_template" "launch_template" {
   ebs_optimized          = var.root_volume_ebs_optimized
   update_default_version = var.update_default_version
 
+  monitoring {
+    enabled = true
+  }
+
   iam_instance_profile {
     name = aws_iam_instance_profile.instance_profile.name
   }

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -19,9 +19,6 @@ data "aws_caller_identity" "current" {}
 resource "aws_autoscaling_group" "autoscaling_group" {
   name_prefix = var.cluster_name
 
-  #  launch_configuration = aws_launch_configuration.launch_configuration.name
-
-  # TODO: Use launch template
   launch_template {
     id      = aws_launch_template.launch_template.id
     version = var.launch_template_version

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -137,6 +137,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     volume_type           = var.root_volume_type
     volume_size           = var.root_volume_size
     delete_on_termination = var.root_volume_delete_on_termination
+    encrypted             = true
   }
 
   # Important note: whenever using a launch configuration with an auto scaling group, you must set

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -112,12 +112,13 @@ resource "aws_autoscaling_group" "autoscaling_group" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_launch_template" "launch_template" {
-  name_prefix   = "${var.cluster_name}-"
-  image_id      = var.ami_id
-  instance_type = var.instance_type
-  user_data     = var.user_data
-  key_name      = var.ssh_key_name
-  ebs_optimized = var.root_volume_ebs_optimized
+  name_prefix            = "${var.cluster_name}-"
+  image_id               = var.ami_id
+  instance_type          = var.instance_type
+  user_data              = var.user_data
+  key_name               = var.ssh_key_name
+  ebs_optimized          = var.root_volume_ebs_optimized
+  update_default_version = var.update_default_version
 
   iam_instance_profile {
     name = aws_iam_instance_profile.instance_profile.name

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -14,8 +14,8 @@ output "cluster_size" {
   value = aws_autoscaling_group.autoscaling_group.desired_capacity
 }
 
-output "launch_config_name" {
-  value = aws_launch_configuration.launch_configuration.name
+output "launch_template_name" {
+  value = aws_launch_template.launch_template.name
 }
 
 output "iam_instance_profile_arn" {

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -242,3 +242,9 @@ variable "iam_permissions_boundary" {
   type        = string
   default     = null
 }
+
+variable "launch_template_version" {
+  description = "Launch template version.  Can be version number, $Latest, or $Default."
+  type        = string
+  default     = "$Latest"
+}

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -248,3 +248,9 @@ variable "launch_template_version" {
   type        = string
   default     = "$Latest"
 }
+
+variable "update_default_version" {
+  description = "Whether to update Default Version each update. Conflicts with default_version."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Encrypt Vault servers' root EBS volume as part of [VSP-22558](https://dreambox.atlassian.net/browse/VSP-22558).  This also updates Vault servers to be provisioned using launch templates instead of launch configs, which will be deprecated soon (see [VSP-23047](https://dreambox.atlassian.net/browse/VSP-23047)).

Successfully applied this and refreshed Vault instances in sre class.